### PR TITLE
fix: missing env for user test cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           echo NODE_ENV=TEST >> .env
           echo ROLLBAR_TOKEN="${{ secrets.ROLLBAR_TOKEN }}" >> .env
           echo ROLLBAR_ENVIRONMENT=development >> .env
+          echo TOKEN="${{ secrets.TOKEN }}" >> .env
           bun install
           bun test
 


### PR DESCRIPTION
`TOKEN` is a environment required for the user test cases to work