### PR TITLE
Potential fix for code scanning alert no. 138: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "mongoose": "^8.6.1",
     "multer": "^1.4.4",
     "multer-storage-cloudinary": "^4.0.0",
-    "rollbar": "^2.26.4"
+    "rollbar": "^2.26.4",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/src/user/user-routes.ts
+++ b/src/user/user-routes.ts
@@ -1,5 +1,6 @@
 // External Modules
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 
 // Internal Modules
 import userController from './user-controller';
@@ -8,13 +9,19 @@ import { userExists, validateUser, validateToken } from './user-middleware';
 
 const userRouter = Router();
 
-userRouter.get('/', validateToken, userController.getUsers);
-userRouter.get('/info', validateToken, userController.getUserInfo);
-userRouter.post('/login', validateUser, userController.login);
-userRouter.post('/create', userExists, userController.createUser);
-userRouter.get('/:id', validateToken, userController.getUser);
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+userRouter.get('/', limiter, validateToken, userController.getUsers);
+userRouter.get('/info', limiter, validateToken, userController.getUserInfo);
+userRouter.post('/login', limiter, validateUser, userController.login);
+userRouter.post('/create', limiter, userExists, userController.createUser);
+userRouter.get('/:id', limiter, validateToken, userController.getUser);
 userRouter.patch(
   '/',
+  limiter,
   validateToken,
   upload.single('image'),
   userController.updatePicture,


### PR DESCRIPTION
Potential fix for [https://github.com/jd-apprentice/waifuland-api/security/code-scanning/138](https://github.com/jd-apprentice/waifuland-api/security/code-scanning/138)

To fix the problem, we need to introduce rate limiting to the routes that perform authorization. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure a rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the routes that require authorization.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/user/user-routes.ts` file.
3. Configure the rate limiter.
4. Apply the rate limiter to the routes that perform authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
