### PR TITLE
Potential fix for code scanning alert no. 129: Database query built from user-controlled sources

### DIFF
--- a/src/user/user-middleware.ts
+++ b/src/user/user-middleware.ts
@@ -60,7 +60,7 @@ const isAdmin = async (
 ): Promise<Boom | NextFunction | Response | unknown> => {
   try {
     const { username } = req.body;
-    const user = await User.findOne({ username });
+    const user = await User.findOne({ username: { $eq: username } });
     return user?.isAdmin ? next() : res.json(boom.unauthorized('Not admin'));
   } catch (error) {
     return res.status(400) && res.json(boom.badRequest('User not found'));


### PR DESCRIPTION
Potential fix for [https://github.com/jd-apprentice/waifuland-api/security/code-scanning/129](https://github.com/jd-apprentice/waifuland-api/security/code-scanning/129)

To fix the problem, we need to ensure that the user input is properly sanitized or validated before being used in the database query. For MongoDB queries, we can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent NoSQL injection attacks.

We will modify the `isAdmin` function to use the `$eq` operator for the `username` field in the query. This change will ensure that the `username` is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
